### PR TITLE
Dots in folder name was causing their splitting as in file extensions

### DIFF
--- a/index.js
+++ b/index.js
@@ -58,7 +58,7 @@ function require_tree (directory, options) {
           , item, obj
 
         if (isDirectory(fpath)) {
-            tree[name] = require_tree(fpath, options)
+            tree[file] = require_tree(fpath, options)
             return
         }
 

--- a/test/app.spec.js
+++ b/test/app.spec.js
@@ -20,6 +20,12 @@ var POA = {
   , bairros: bairros
 }
 
+var VERSIONED = {
+    '1.0.0': {
+        v1: 'success'
+    }
+}
+
 describe('when given a file tree', function(){
 
     it('returned object should match file structure', function(){
@@ -32,6 +38,15 @@ describe('when given a file tree', function(){
         assert.deepEqual(poa, POA)
     })
 
+})
+
+describe('folder name', function() {
+    
+    it('should be mapped as named in filesystem', function(){
+        var versioned = require_tree('./dot-in-foldername')
+        assert.deepEqual(versioned, VERSIONED)
+    });
+    
 })
 
 describe('paths', function(){

--- a/test/dot-in-foldername/1.0.0/v1.js
+++ b/test/dot-in-foldername/1.0.0/v1.js
@@ -1,0 +1,1 @@
+module.exports = 'success';


### PR DESCRIPTION
Dots in folder name was causing their splitting as in file extensions
For example, a folder named 1.0.0 got mapped as 1.0
