### PR TITLE
accept use of relative paths when  is defined

### DIFF
--- a/index.js
+++ b/index.js
@@ -36,8 +36,8 @@ function require_tree (directory, options) {
         index: true
     }, options)
 
-    var parentDir = path.dirname(module.parent.filename)
-      , dir       = path.resolve(parentDir, directory)
+    var baseDir   = process.env.NODE_PATH || path.dirname(module.parent.filename)
+      , dir       = path.resolve(baseDir, directory)
       , forbidden = ['.json', '.node']
       , filter    = options.filter
       , tree      = {}


### PR DESCRIPTION
I think we should be able to pass relative path from the project root, if the $NODE_PATH is defined, just like node require() does.

Reference: [Better local require() paths for Node.js](https://gist.github.com/branneman/8048520#4-the-environment)
