### PR TITLE
Remove NODE_PATH

### DIFF
--- a/index.js
+++ b/index.js
@@ -29,7 +29,7 @@ function require_tree (directory, options) {
         index: 'merge'
     }, options)
 
-    var baseDir   = process.env.NODE_PATH || path.dirname(module.parent.filename)
+    var baseDir   = path.dirname(module.parent.filename)
       , dir       = path.resolve(baseDir, directory)
       , forbidden = ['.json', '.node']
       , filter    = getFilter(options.filter) || Boolean


### PR DESCRIPTION
Compared to other runtimes like ruby and python and perl, NODE_PATH is used far less often. Also NODE_PATH is a search path, not a single directory.  Instead we could remove this and probably search each parent directory for one that contains node_modules and stop when it finds one.