### PR TITLE
fix bug about checking if dir exists

### DIFF
--- a/index.js
+++ b/index.js
@@ -44,8 +44,12 @@ function require_tree (directory, options) {
     var exists = baseDirs.some(function(baseDir){
         try {
             dir = path.resolve(baseDir, directory)
-            fs.accessSync ? fs.accessSync(dir) : fs.existsSync(dir)
-            return true
+            if(fs.accessSync) {
+                 fs.accessSync(dir)
+                 return true
+            } else {
+                 return fs.existsSync(dir)
+            }
         } catch (err) {}
     })
 


### PR DESCRIPTION
When using node v0.10.37, `npm test` failed.

```
vagrant@vagrant-ubuntu-trusty-32:~/require-tree$ npm test

> require-tree@1.1.1 test /home/vagrant/require-tree
> mocha



  when given a file tree
    1) returned object should match file structure
    2) returned object should merge index into root object

  folder name
    3) should be mapped as named in filesystem

  paths
    4) should be relative to parent module
    ✓ should accept absolute paths
    5) should resolve relative paths
    NODE PATH
      ✓ should be used for lookup if present
      6) should accept multiple paths

  when given the index option
    preserve
      7) should put index under it's own key
      8) should put index under it's own key (index: true)
    merge
      9) should merge index at the root
    ignore
      10) should not load index
      11) should not load index (index: false)

  when given the each option
    12) should run once for each file

  when given the transform option
    13) should redefine the exports object

  when given the name option
    with a function
      14) should run once for each file
      15) should define the exports name
      16) should be able to access the export object
    with a string
      17) should use the string as key for the export name

  when given the keys option
    with a function
      18) should run once for each key
      19) should filter the exports object
    with an array
      20) should filter the exports object
    with a string
      21) should filter the exports object

  when given the filter option
    as a string
      22) should filter the required files
    as a regular expression
      23) should filter the required files
    as a function
      24) should filter the required files


  2 passing (48ms)
  24 failing

  1) when given a file tree returned object should match file structure:
     Error: ENOENT, no such file or directory '/usr/lib/nodejs/porto-alegre'
      at Object.fs.readdirSync (fs.js:666:18)
      at require_tree (index.js:56:8)
      at Context.<anonymous> (test/app.spec.js:34:19)

  2) when given a file tree returned object should merge index into root object:
     Error: ENOENT, no such file or directory '/usr/lib/nodejs/porto-alegre'
      at Object.fs.readdirSync (fs.js:666:18)
      at require_tree (index.js:56:8)
      at Context.<anonymous> (test/app.spec.js:39:19)

...
```

This is caused by how to check if a directory exists using `fs.existsSync`.
[require-tree/index.js at d60aa8691f3955640366ad57e25df6bcc1da6604 · ricardobeat/require-tree](https://github.com/ricardobeat/require-tree/blob/d60aa8691f3955640366ad57e25df6bcc1da6604/index.js#L47)

I think that `fs.existsSync` doesn't throw any exception.
[node/fs.js at 2b15e68bbee031eb7d027efa24fb6a220f823c82 · nodejs/node](https://github.com/nodejs/node/blob/2b15e68bbee031eb7d027efa24fb6a220f823c82/lib/fs.js#L220)
